### PR TITLE
fetchFn proposal

### DIFF
--- a/packages/metal-router/README.md
+++ b/packages/metal-router/README.md
@@ -103,7 +103,7 @@ the promise is resolved.
 ### Fetching
 
 Data from an Ajax request can easily be passed to the `component`
-via the `fetch` and `fetchUrl` config properties.
+via the `fetch` and `fetchUrl` or `fetchFn` config properties.
 
 ```javascript
 Component.render(Router, {
@@ -114,9 +114,22 @@ Component.render(Router, {
 });
 ```
 
+
 This will fire off a request to `/some/api.json` when `/path` is navigated to,
 and pass the returned data directly to `MyComponent`. Note that the component
 will not be rendered until the request is complete.
+
+`fetchFn` can also be used for cases where the direct API isn't helpful. Any
+returned data in the promise will be pass directly to `MyComponent`.
+
+```javascript
+Component.render(Router, {
+  component: MyComponent,
+  fetch: true,
+  fetchFn: () => new Promise(resolve => resolve({title: 'Foo Bar'})),
+  path: '/path'
+});
+```
 
 Use the `fetchTimeout` property for setting a max amount of time
 for the request.

--- a/packages/metal-router/src/Router.js
+++ b/packages/metal-router/src/Router.js
@@ -278,6 +278,13 @@ Router.STATE = {
 	},
 
 	/**
+	 * Function to call before navigating to a certain path.
+	 */
+	fetchFn: {
+		validator: val => core.isFunction(val),
+	},
+
+	/**
 	 * Url to be used when fetching data for this route. If nothing is given,
 	 * the current path will be used by default. Note that this is only relevant
 	 * if "fetch" is set to `true`.
@@ -461,7 +468,13 @@ class ComponentScreen extends RequestScreen {
 		let deferred = CancellablePromise.resolve();
 		let params;
 		if (this.router.fetch) {
-			deferred = deferred.then(() => super.load(this.getFetchUrl_(path)));
+			if (this.router.fetchFn) {
+				deferred = deferred.then(() => this.router.fetchFn(path));
+			} else {
+				deferred = deferred.then(() =>
+					super.load(this.getFetchUrl_(path))
+				);
+			}
 		} else {
 			params = this.router.extractParams(path);
 			deferred = deferred.then(() => this.router.data(path, params));

--- a/packages/metal-router/test/Router.js
+++ b/packages/metal-router/test/Router.js
@@ -236,6 +236,23 @@ describe('Router', function() {
 			});
 	});
 
+	it('should run fetchFn callback and add to lastLoadedState', function(done) {
+		router = new Router({
+			path: '/path',
+			component: CustomComponent,
+			fetch: true,
+			fetchFn: () => {
+				return new Promise((resolve) => setTimeout(() => resolve({title: 'Foo Bar'}), 300));
+			},
+		});
+		Router.router()
+			.navigate('/path')
+			.then(() => {
+				assert.deepEqual({title: 'Foo Bar'}, router.lastLoadedState);
+				done();
+			});
+	});
+
 	it('should fetch data from url specified by "fetchUrl" function when "fetch" is true', function(done) {
 		let stub = sinon
 			.stub(RequestScreen.prototype, 'load')


### PR DESCRIPTION
We were looking for a way to pre-request any data that might be on our next route. `fetchUrl` wasn't helpful enough since we will need to change state in the parent component or might need to massage the ajax response before passing it to the route component. Let me know what you think.

Not sure if the name `fetchFn` makes sense, but I think the functionality is a good idea.