### PR TITLE
[metal-router] Adds async way to render component

### DIFF
--- a/packages/metal-router/demos/src/Basic.js
+++ b/packages/metal-router/demos/src/Basic.js
@@ -8,23 +8,29 @@ import './Image.soy.js';
 
 // Routing from JavaScript -----------------------------------------------------
 
-var Basic = {
+let Basic = {
 	run() {
 		Component.render(Router, {
 			element: '#main > div',
 			fetch: true,
 			fetchUrl: '/demos/data.json',
 			path: '/demos/basic',
-			component: Home
+			component: Home,
 		});
 
 		Component.render(Router, {
+			async: true,
 			element: '#main > div',
 			path: '/demos/basic/home-page',
-			component: Home,
+			component: () =>
+				new Promise(res => {
+					setTimeout(() => {
+						res(Home);
+					}, 1000);
+				}),
 			data: {
-				title: 'Home Page'
-			}
+				title: 'Home Page Delayed',
+			},
 		});
 
 		Component.render(Router, {
@@ -32,8 +38,8 @@ var Basic = {
 			path: '/demos/basic/about/:name(\\w+)?',
 			component: About,
 			data: {
-				title: 'About'
-			}
+				title: 'About',
+			},
 		});
 
 		Component.render(Router, {
@@ -41,14 +47,16 @@ var Basic = {
 			path: '/demos/basic/about-delayed',
 			component: About,
 			data: function() {
-				return new Promise((resolve) => setTimeout(() => resolve({ title: 'About Delayed' }), 2000));
-			}
+				return new Promise(resolve =>
+					setTimeout(() => resolve({title: 'About Delayed'}), 2000)
+				);
+			},
 		});
 
 		// Dispatch router to the current browser url ----------------------------------
 
 		Router.router().dispatch();
-	}
+	},
 };
 
 export default Basic;

--- a/packages/metal-router/src/Router.js
+++ b/packages/metal-router/src/Router.js
@@ -223,6 +223,16 @@ Router.RENDERER = IncrementalDomRenderer;
  */
 Router.STATE = {
 	/**
+	 * Flag indicating if the component should be loaded via a request
+	 * to the server.
+	 * @type {boolean}
+	 * @default false
+	 */
+	async: {
+		validator: core.isBoolean,
+		value: false,
+	},
+	/**
 	 * Handler to be called before a router is activated. Can be given as a
 	 * function reference directly, or as the name of a function to be called in
 	 * the router's component instance.
@@ -466,6 +476,21 @@ class ComponentScreen extends RequestScreen {
 			params = this.router.extractParams(path);
 			deferred = deferred.then(() => this.router.data(path, params));
 		}
+
+		if (this.router.async) {
+			deferred = deferred.then(loadedState =>
+				this.router.component().then(component => {
+					this.router.component = component;
+
+					if (this.router.cacheable) {
+						this.router.async = false;
+					}
+
+					return loadedState;
+				})
+			);
+		}
+
 		return deferred.then(loadedState => {
 			this.router.lastPath = path;
 			this.router.lastRedirectPath = this.maybeFindRedirectPath();

--- a/packages/metal-router/test/Router.js
+++ b/packages/metal-router/test/Router.js
@@ -491,6 +491,27 @@ describe('Router', function() {
 			});
 	});
 
+	it('should render component asyncronously', function(done) {
+		router = new Router({
+			async: true,
+			path: '/path2',
+			component: () =>
+				new CancellablePromise(resolve => {
+					setTimeout(() => {
+						resolve(CustomComponent);
+					}, 200);
+				}),
+		});
+
+		Router.router()
+			.navigate('/path2')
+			.then(() => {
+				assert.ok(Router.getActiveComponent() instanceof CustomComponent);
+				assert.ok(Router.getActiveComponent().wasRendered);
+				done();
+			});
+	});
+
 	it('should render component with right element when routing to path', function(done) {
 		dom.append(document.body, '<div id="el"><div></div></div>');
 		let element = document.querySelector('#el > div');


### PR DESCRIPTION
Added in functionality so that users have the ability to asynchronously render the component for a given route. This will help give users the ability to use code splitting and seamlessly transition between routes where the bundle may not have been loaded yet.

Using webpack's [dynamic import](https://webpack.js.org/guides/code-splitting/#dynamic-imports) for code splitting, we can do something like this

```jsx
<Router
	async
	component={() => import('./FooComponent').then(module => module.default)}
	path="/foo"
/>
```

FYI, since `metal-router` has the ability to cache components for routes, we have to make sure and disable async once the component has been cached([see change](https://webpack.js.org/guides/code-splitting/#dynamic-imports)).