### PR TITLE
[metal-router] Use private asyncComponent attribute rather than overriding component

### DIFF
--- a/packages/metal-router/src/Router.js
+++ b/packages/metal-router/src/Router.js
@@ -147,8 +147,10 @@ class Router extends Component {
 	 */
 	render() {
 		if (this.isActive_) {
+			const component = this.asyncComponent_ || this.component;
+
 			IncrementalDOM.elementVoid(
-				this.component,
+				component,
 				null,
 				null,
 				'ref',
@@ -232,6 +234,13 @@ Router.STATE = {
 		validator: core.isBoolean,
 		value: false,
 	},
+
+	/**
+	 * Internal value for the constructor of the component that was loaded
+	 * async. This component overrides the original component.
+	 * @type {!Function}
+	 */
+	asyncComponent_: {},
 
 	/**
 	 * Handler to be called before a router is activated. Can be given as a
@@ -481,7 +490,7 @@ class ComponentScreen extends RequestScreen {
 		if (this.router.async) {
 			deferred = deferred.then(loadedState =>
 				this.router.component().then(component => {
-					this.router.component = component;
+					this.router.asyncComponent_ = component;
 
 					if (this.router.cacheable) {
 						this.router.async = false;


### PR DESCRIPTION
In the previous PR I sent(https://github.com/metal/metal-plugins/pull/18) I didn't account for the instance where the parent component re-renders. When this is the case, the parent component passes through `() => import()` again. We want to avoid this and use the cached version of the component that was previously loaded.

Example
```jsx
class Parent extends Component {
     render() {
          return (
                <div>
                     {this.props.name)

                     <Router
                          async={true}
                          component={() => import('./Home).then(module => module.default)}
                          path="/"
                     />
                </div>
     }
```

If `Parent` receives a new `name` prop. It causes Router to re-render with the function rather than the loaded component.