### PR TITLE
Fixes #97 | Prevent placeholder to target itself

### DIFF
--- a/packages/metal-drag-drop/src/Drag.js
+++ b/packages/metal-drag-drop/src/Drag.js
@@ -723,7 +723,7 @@ class Drag extends State {
 	 */
 	toElements_(elementOrSelector) {
 		if (core.isString(elementOrSelector)) {
-			let matched = this.container.querySelectorAll(elementOrSelector);
+			let matched = this.container.querySelectorAll(`${elementOrSelector}:not([aria-grabbed="true"])`);
 			return Array.prototype.slice.call(matched, 0);
 		} else if (elementOrSelector) {
 			return [elementOrSelector];

--- a/packages/metal-drag-drop/src/Drag.js
+++ b/packages/metal-drag-drop/src/Drag.js
@@ -723,7 +723,9 @@ class Drag extends State {
 	 */
 	toElements_(elementOrSelector) {
 		if (core.isString(elementOrSelector)) {
-			let matched = this.container.querySelectorAll(`${elementOrSelector}:not([aria-grabbed="true"])`);
+			let matched = this.container.querySelectorAll(
+				`${elementOrSelector}:not([aria-grabbed="true"])`
+			);
 			return Array.prototype.slice.call(matched, 0);
 		} else if (elementOrSelector) {
 			return [elementOrSelector];


### PR DESCRIPTION
`aria-grabbed=true` is set for any drag placeholder, considering this when can prevent appending selector `not` when querying elements.