### PR TITLE
Fix metal-drag-drop for complex target selectors

### DIFF
--- a/packages/metal-drag-drop/src/Drag.js
+++ b/packages/metal-drag-drop/src/Drag.js
@@ -723,10 +723,10 @@ class Drag extends State {
 	 */
 	toElements_(elementOrSelector) {
 		if (core.isString(elementOrSelector)) {
-			let matched = this.container.querySelectorAll(
-				`${elementOrSelector}:not([aria-grabbed="true"])`
-			);
-			return Array.prototype.slice.call(matched, 0);
+			const matched = this.container.querySelectorAll(elementOrSelector);
+			return Array.prototype
+				.slice.call(matched, 0)
+				.filter(element => element.matches(':not([aria-grabbed="true"])'));
 		} else if (elementOrSelector) {
 			return [elementOrSelector];
 		} else {

--- a/packages/metal-drag-drop/test/Drag.js
+++ b/packages/metal-drag-drop/test/Drag.js
@@ -809,6 +809,25 @@ describe('Drag', function() {
 			assert.deepEqual([scroll, scroll2, document], drag.scrollContainers);
 		});
 
+		it('should support "scrollContainers" complex selectors', function() {
+			let scroll = document.querySelector('.scroll');
+			let scroll2 = scroll.cloneNode(true);
+
+			dom.enterDocument(scroll2);
+			dom.addClasses(scroll, 'scroll1');
+			dom.addClasses(scroll2, 'scroll2');
+
+			drag = new Drag({
+				scrollContainers: `
+          .scroll1,
+					.scroll2
+        `,
+				sources: item,
+			});
+
+			assert.deepEqual([scroll, scroll2, document], drag.scrollContainers);
+		});
+
 		it('should ignore elements that match "scrollContainers" selector that are outside "container"', function() {
 			let scroll = document.querySelector('.scroll');
 			let scroll2 = scroll.cloneNode(true);

--- a/packages/metal-drag-drop/test/Drag.js
+++ b/packages/metal-drag-drop/test/Drag.js
@@ -809,6 +809,18 @@ describe('Drag', function() {
 			assert.deepEqual([scroll, scroll2, document], drag.scrollContainers);
 		});
 
+		it('should avoid aria grabbled elements in scrollContainers', function() {
+			let scroll = document.querySelector('.scroll');
+			scroll.setAttribute('aria-grabbed', 'true');
+
+			drag = new Drag({
+				scrollContainers: '.scroll',
+				sources: item,
+			});
+
+			assert.deepEqual([document], drag.scrollContainers);
+		});
+
 		it('should support "scrollContainers" complex selectors', function() {
 			let scroll = document.querySelector('.scroll');
 			let scroll2 = scroll.cloneNode(true);


### PR DESCRIPTION
Fixes #114 
Element.matches support: https://developer.mozilla.org/en-US/docs/Web/API/Element/matches